### PR TITLE
ESP-IDF 5 ADC Implementation Updates for Wall-E 

### DIFF
--- a/2_LSA/main/main.c
+++ b/2_LSA/main/main.c
@@ -23,7 +23,8 @@ static const char *TAG = "LSA_READINGS";
 void app_main(void)
 {
     // enable line sensor after checking optimal working state of ESP
-    ESP_ERROR_CHECK(enable_line_sensor());
+    adc_handle_t line_sensor;
+    ESP_ERROR_CHECK(enable_line_sensor(&line_sensor));
 
     // Union containing line sensor readings
     line_sensor_array line_sensor_readings;
@@ -41,7 +42,7 @@ void app_main(void)
     while (1)
     {
         // get line sensor readings from the LSA sensors
-        line_sensor_readings = read_line_sensor();
+        line_sensor_readings = read_line_sensor(line_sensor);
         for (int i = 0; i < 5; i++)
         {
             // constrain lsa readings between BLACK_MARGIN and WHITE_MARGIN

--- a/6_line_following/main/line_following.c
+++ b/6_line_following/main/line_following.c
@@ -110,7 +110,8 @@ void line_follow_task(void* arg)
     motor_handle_t motor_a_0, motor_a_1;
     ESP_ERROR_CHECK(enable_motor_driver(&motor_a_0, MOTOR_A_0));
     ESP_ERROR_CHECK(enable_motor_driver(&motor_a_1, MOTOR_A_1));
-    ESP_ERROR_CHECK(enable_line_sensor());
+    adc_handle_t line_sensor;
+    ESP_ERROR_CHECK(enable_line_sensor(&line_sensor));
     ESP_ERROR_CHECK(enable_bar_graph());
 #ifdef CONFIG_ENABLE_OLED
     // Initialising the OLED
@@ -124,7 +125,7 @@ void line_follow_task(void* arg)
 
     while(true)
     {
-        line_sensor_readings = read_line_sensor();
+        line_sensor_readings = read_line_sensor(line_sensor);
         for(int i = 0; i < 5; i++)
         {
             line_sensor_readings.adc_reading[i] = bound(line_sensor_readings.adc_reading[i], WHITE_MARGIN, BLACK_MARGIN);


### PR DESCRIPTION
This PR contains the changes for using the new ADC implementation as per ESP-IDF 5.1.

With this PR, Wall-E will use the new SRA Board component including the ADC changes for ESP-IDF 5.1. Now, we require to create an `adc_handle_t` , which is an object of the adc driver, to read from the ADC.

Please review and let me know your suggestions.