### PR TITLE
update pwm constraint values for easy bot performance

### DIFF
--- a/5_line_following/README.md
+++ b/5_line_following/README.md
@@ -138,3 +138,11 @@ Integral Term = Ki*(Cumulative Error)
     **Description** : Starts an HTTP server that allows remote tuning of PID parameters via a web interface
 
     **Parameters** : None
+
+## Default PWM Settings (Wall‑Ev2.7)
+
+- Recommended base and bounds for motor duty cycles:
+  - `optimum_duty_cycle = 40`
+  - `lower_duty_cycle = 10`
+  - `higher_duty_cycle = 55`
+- Update these in `5_line_following/main/line_following.c` to match your bot.

--- a/5_line_following/main/line_following.c
+++ b/5_line_following/main/line_following.c
@@ -21,9 +21,10 @@ const int weights[5] = {-5, -3, 1, 3, 5};
 /*
  * Motor value boundts
  */
-int optimum_duty_cycle = 57;
-int lower_duty_cycle = 45;
-int higher_duty_cycle = 65;
+// Updated PWM settings per bot tuning
+int optimum_duty_cycle = 40;
+int lower_duty_cycle = 10;
+int higher_duty_cycle = 55;
 float left_duty_cycle = 0, right_duty_cycle = 0;
 
 /*

--- a/6_self_balancing/README.md
+++ b/6_self_balancing/README.md
@@ -126,3 +126,10 @@ Integral Term = ki*(Integral_Error)
     * `mpu_offset` : mpu_offsets are the initial accelerometer angles at rest position
 
     **Return** : returns ESP_OK if calculate angles correctly else return ESP_FAIL if any error occurs
+
+## Default PWM Settings (Wall‑Ev2.7)
+
+- Recommended duty cycle bounds for motors while balancing:
+  - `MAX_PWM = 60`
+  - `MIN_PWM = 30`
+- Adjust in code at `6_self_balancing/main/self_balancing.c` if your hardware differs.

--- a/6_self_balancing/main/self_balancing.c
+++ b/6_self_balancing/main/self_balancing.c
@@ -15,8 +15,9 @@
 #define MAX_PITCH_AREA (850.0f)
 #define MAX_PITCH_RATE (850.0f)
 
-#define MAX_PWM (80.0f)
-#define MIN_PWM (60.0f)
+// Updated PWM bounds per bot tuning
+#define MAX_PWM (60.0f)
+#define MIN_PWM (30.0f)
 
 /**
 * Self Balancing Tuning Parameters

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ The Wall-E workshop focuses on the concepts of line-following and self-balancing
 
 <!-- ROADMAP -->
 
+## Wall‑Ev2.7 Motor PWM Settings
+
+- Self‑Balancing (duty cycle bounds)
+  - `MAX_PWM = 60`
+  - `MIN_PWM = 30`
+- Line‑Following (base and bounds)
+  - `optimum_duty_cycle = 40`
+  - `lower_duty_cycle = 10`
+  - `higher_duty_cycle = 55`
+
+Code locations for these defaults:
+- Self‑Balancing: `6_self_balancing/main/self_balancing.c`
+- Line‑Following: `5_line_following/main/line_following.c`
+
+
 ## Resources
 
 - Please visit and look at our [Custom-made SRA development board](https://github.com/SRA-VJTI/sra-board-hardware-design)
@@ -124,5 +139,4 @@ Contributions are what make the open source community such an amazing place to b
 [issues-url]: https://github.com/SRA-VJTI/Wall-E/issues
 [license-shield]: https://img.shields.io/github/license/SRA-VJTI/Wall-E
 [license-url]: https://github.com/SRA-VJTI/Wall-E/blob/master/LICENSE
-
 


### PR DESCRIPTION
The previous defaults were too fast for the current bot design. Based on testing on Wall‑Ev2.7, this PR updates motor PWM bounds and documents the new recommended values.

  Changes

  - Self‑Balancing: update duty cycle bounds
      - 6_self_balancing/main/self_balancing.c: #define MAX_PWM (60.0f)
      - 6_self_balancing/main/self_balancing.c: #define MIN_PWM (30.0f)
  - Line‑Following: update base and bounds
      - 5_line_following/main/line_following.c: int optimum_duty_cycle = 40;
      - 5_line_following/main/line_following.c: int lower_duty_cycle = 10;
      - 5_line_following/main/line_following.c: int higher_duty_cycle = 55;
  - Documentation:
      - Add Wall‑Ev2.7 PWM settings in root README.md
      - Add defaults sections in 6_self_balancing/README.md and 5_line_following/README.md